### PR TITLE
Add new mobile area code blocks

### DIFF
--- a/tex/phonenumbers-DE.def
+++ b/tex/phonenumbers-DE.def
@@ -5231,7 +5231,26 @@
 01529,
 015510,
 015511,
+015550,
+015551,
+015552,
+015553,
+015554,
+015555,
+015556,
+015557,
+015558,
+015559,
+015560,
+015561,
+015562,
+015563,
+015564,
+015565,
 015566,
+015567,
+015568,
+015569,
 015630,
 015678,
 01570,
@@ -10513,7 +10532,26 @@
 \tl_const:cn {c_phone_DE_ortsname_01529_tl} {Mobilfunk}
 \tl_const:cn {c_phone_DE_ortsname_015510_tl} {Mobilfunk}
 \tl_const:cn {c_phone_DE_ortsname_015511_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015550_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015551_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015552_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015553_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015554_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015555_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015556_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015557_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015558_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015559_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015560_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015561_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015562_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015563_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015564_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015565_tl} {Mobilfunk}
 \tl_const:cn {c_phone_DE_ortsname_015566_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015567_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015568_tl} {Mobilfunk}
+\tl_const:cn {c_phone_DE_ortsname_015569_tl} {Mobilfunk}
 \tl_const:cn {c_phone_DE_ortsname_015630_tl} {Mobilfunk}
 \tl_const:cn {c_phone_DE_ortsname_015678_tl} {Mobilfunk}
 \tl_const:cn {c_phone_DE_ortsname_01570_tl} {Mobilfunk}


### PR DESCRIPTION
Hello,
this PR adds a number of recently allocated mobile area codes. 
The information which area codes are currently allocated can be found here: https://www.bundesnetzagentur.de/DE/Fachthemen/Telekommunikation/Nummerierung/MobileDienste/zugeteilteRNB/start.html

However, I do not know whether this source is comprehensive or not.

Please let me know in case this PR requires any changes in order to be merged. 